### PR TITLE
Accurately represent progress on milestone achievements

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -2035,7 +2035,13 @@ export const store = createStore({
                 if (item.count < item.brackets.length) {
                 
                     let limit = item.brackets[item.count]
-                    item.progress = 100 * state.data[item.data].count / limit
+                  if (item.count === 0) {
+                    item.progress = (100 * state.data[item.data].count) / limit
+                  } else {
+                    const prev = item.brackets[item.count - 1]
+                    item.progress =
+                      (100 * (state.data[item.data].count - prev)) / (limit - prev)
+                  }
                     if (item.progress >= 100) {
                         item.count += 1
                         commit('addNotif', 'achievementPane')

--- a/src/store.js
+++ b/src/store.js
@@ -2035,13 +2035,13 @@ export const store = createStore({
                 if (item.count < item.brackets.length) {
                 
                     let limit = item.brackets[item.count]
-                  if (item.count === 0) {
-                    item.progress = (100 * state.data[item.data].count) / limit
-                  } else {
-                    const prev = item.brackets[item.count - 1]
-                    item.progress =
-                      (100 * (state.data[item.data].count - prev)) / (limit - prev)
-                  }
+                    if (item.count === 0) {
+                      item.progress = (100 * state.data[item.data].count) / limit
+                    } else {
+                      const prev = item.brackets[item.count - 1]
+                      item.progress =
+                        (100 * (state.data[item.data].count - prev)) / (limit - prev)
+                    }
                     if (item.progress >= 100) {
                         item.count += 1
                         commit('addNotif', 'achievementPane')


### PR DESCRIPTION
Previously, upon achieving any of the machine count or resource count milestone achievements, the progress bar would inaccurately represent progress towards the next milestone- for instance, when achieving the 5 Miners Achievement, if I have just 5 Miners, it shows progress towards 25 as more substantial than it is:
![localhost_8080_](https://user-images.githubusercontent.com/6620407/132239755-94df01a8-8636-482e-8d96-e4fc8f5978ab.png)
This is exacerbated especially at the higher achievement levels, effectively making the progress bars useless. This PR changes the calculation of these mini-progress bars to show the progress from the previous milestone to the next, making it much clearer which achievements you are actually closest to. 
Here are the same 5 Miners after this change:
![localhost_8080_ (1)](https://user-images.githubusercontent.com/6620407/132240031-d0a89b7f-5f75-42a7-83da-11c599b2e179.png)
(Instead of showing 5/25, this shows 0/20, which more accurately represents the notion the segmented progress bars represent)