### PR TITLE
Add Nanoswarm shortcut to upgrade costs breakdown

### DIFF
--- a/frontend/src/components/CalcBuilding.vue
+++ b/frontend/src/components/CalcBuilding.vue
@@ -11,6 +11,9 @@
                 <div class="col">
                     <small class="text-light">{{ $t(cost.id) }}</small>
                 </div>
+                <div class="col-auto" v-if="costTo(bracket, cost.count, data[id].count, cost.id) > data[cost.id].count">
+                    <nanoswarm-shortcut :resource="cost.id" />
+                </div> 
                 <div class="col-auto">
                     <small class="text-uppercase" :class="{ 'text-light':costTo(bracket, cost.count, data[id].count, cost.id) <= data[cost.id].storage, 'text-excess':costTo(bracket, cost.count, data[id].count, cost.id) <= getStorageCap(cost.id) && costTo(bracket, cost.count, data[id].count, cost.id) > data[cost.id].storage, 'text-danger':costTo(bracket, cost.count, data[id].count, cost.id) > getStorageCap(cost.id) }"><format-number :value="costTo(bracket, cost.count, data[id].count, cost.id)" /></small>
                 </div>
@@ -28,6 +31,7 @@
 <script>
 import Timer from './Timer.vue'
 import FormatNumber from './FormatNumber.vue'
+import NanoswarmShortcut from './NanoswarmShortcut.vue'
 
 import { mapState, mapGetters } from 'vuex'
 
@@ -35,6 +39,7 @@ export default {
     components: {
         'timer': Timer,
         'format-number': FormatNumber,
+        'nanoswarm-shortcut': NanoswarmShortcut,
     },
     props: [ 'id' ],
     computed: {

--- a/frontend/src/components/CalcSegment.vue
+++ b/frontend/src/components/CalcSegment.vue
@@ -12,6 +12,9 @@
                 <div class="col">
                     <small class="text-light">{{ $t(resource) }}</small>
                 </div>
+                <div class="col-auto" v-if="maxCount.store[resource].count > data[resource].count">
+                    <nanoswarm-shortcut :resource="resource" />
+                </div> 
                 <div class="col-auto">
                     <small class="text-uppercase" :class="{ 'text-light':maxCount.store[resource].count <= data[resource].storage, 'text-excess':maxCount.store[resource].count <= getStorageCap(resource) && maxCount.store[resource].count > data[resource].storage, 'text-danger':maxCount.store[resource].count > getStorageCap(resource) }"><format-number :value="maxCount.store[resource].count" /></small>
                 </div>
@@ -30,6 +33,7 @@
 <script>
 import Timer from './Timer.vue'
 import FormatNumber from './FormatNumber.vue'
+import NanoswarmShortcut from './NanoswarmShortcut.vue'
 
 import { mapState, mapGetters } from 'vuex'
 
@@ -38,6 +42,7 @@ export default {
     
         'timer': Timer,
         'format-number': FormatNumber,
+        'nanoswarm-shortcut': NanoswarmShortcut,
     },
     computed: {
     
@@ -81,7 +86,7 @@ export default {
                 meteorite: { count: costMeteorite, timer: this.data['meteorite'].prod > 0 ? (costMeteorite - this.data['meteorite'].count) / this.data['meteorite'].prod : 0 },
                 ice: { count: costIce, timer: this.data['ice'].prod > 0 ? (costIce - this.data['ice'].count) / this.data['ice'].prod : 0 },
             }
-        }
+        },
     },
 }
 </script>

--- a/frontend/src/components/Costs.vue
+++ b/frontend/src/components/Costs.vue
@@ -37,6 +37,9 @@
                     </div>
                 </button>
             </div>
+            <div class="col-auto" v-if="cost.timer > 0">
+                <nanoswarm-shortcut :resource="cost.id" />
+            </div>
             <div class="col-auto">
                 <button v-if="displayEmcShortcut && data['emc'].unlocked == true && cost.timer > 0 && isEmcResource(data, getEmcId(cost.id))" class="me-3" @click="if (cost.id != 'segment' && data[cost.id].unlocked == true) { convert(getEmcId(cost.id)); }">
                     <img v-if="cost.id !== 'meteorite'" :src="require(`../assets/interface/energy.png`)" width="12" height="12" :alt="$t('energy') + ' icon'" />
@@ -62,6 +65,7 @@
 <script>
 import Timer from './Timer.vue'
 import FormatNumber from './FormatNumber.vue'
+import NanoswarmShortcut from './NanoswarmShortcut.vue'
 
 import { mapState, mapActions, mapMutations } from 'vuex'
 
@@ -69,11 +73,12 @@ export default {
     components: {
         'timer': Timer,
         'format-number': FormatNumber,
+        'nanoswarm-shortcut': NanoswarmShortcut,
     },
     props: [ 'costs', 'mod', 'id', 'calc' ],
     computed: {
         ...mapState([
-            'data', 'displayEmcShortcut'
+            'data', 'displayEmcShortcut',
         ]),
         maxBuildable: function() {
             

--- a/frontend/src/components/NanoswarmShortcut.vue
+++ b/frontend/src/components/NanoswarmShortcut.vue
@@ -1,0 +1,42 @@
+<template>
+    <button v-if="displayNanoswarmShortcut" :class="buttonStyles" @click.stop="switchNano(resource)">
+        <img 
+            :src="require(data['nanoswarm'].resource !== resource ? '../assets/interface/nanoswarm.png':'../assets/interface/nanoswarm_green.png')" 
+            :width="imgSize"
+            :height="imgSize" 
+            alt="nanoswarm icon" 
+        />
+    </button>          
+</template>
+
+<script>
+
+import { mapState, mapActions } from 'vuex'
+
+export default {
+    props: {
+        resource: {
+            type: String,
+            required: true
+        },
+        buttonStyles: {
+            type: String,
+            default: 'me-3'
+        },
+        imgSize: {
+            type: String,
+            default: '12'
+        }
+    },    
+    computed: {    
+        ...mapState([
+            'data', 'displayNanoswarmShortcut'
+        ]),
+    },
+    methods: {
+        ...mapActions([
+            'switchNano'
+        ]),
+    },
+}
+</script>

--- a/frontend/src/components/SidenavItem.vue
+++ b/frontend/src/components/SidenavItem.vue
@@ -35,12 +35,10 @@
                         </div>
                     </div>
                 </button>
-            </div>
-            <div v-if="prod !=null && displayNanoswarmShortcut" class="col-auto" >
-                <button class="btn btn-small" @click.stop="switchNano(this.shortId)">
-                    <img :src="require(!selected?'../assets/interface/nanoswarm.png':'../assets/interface/nanoswarm_green.png')" width="14" height="14" alt="nanoswarm icon" />
-                </button>
-            </div>
+            </div>            
+            <div class="col-auto" v-if="prod !=null">
+                <nanoswarm-shortcut :resource="this.shortId" buttonStyles="btn btn-small" imgSize="14" />
+            </div> 
             <div class="col-auto" style="width: 27px;">
                 <button v-if="buildingStorageId && data['techStorage'].count > 0" :id="'tpUpgradeStorage' + buildingStorageId" class="btn btn-small" :class="{ 'disabled text-muted':!canBuild(buildingStorageId) }" aria-label="Upgrade storage" @click.stop="build({id:buildingStorageId, count:1})">
                     <i class="fas fa-fw fa-arrow-alt-circle-up"></i>
@@ -68,6 +66,7 @@
 
 <script>
 import FormatNumber from './FormatNumber.vue'
+import NanoswarmShortcut from './NanoswarmShortcut.vue'
 
 import { Tooltip } from 'bootstrap'
 
@@ -77,24 +76,24 @@ export default {
     props: [ 'id', 'unlocked', 'icon', 'prod', 'count', 'cap', 'storage', 'opinion', 'done', 'doneText', 'potential', 'problem', 'buildingStorageId' ],
     components: {
         'format-number': FormatNumber,
+        'nanoswarm-shortcut': NanoswarmShortcut,
     },
     computed: {
         ...mapState([        
-            'data', 'activePane', 'displayNanoswarmShortcut',
+            'data', 'activePane',
         ]),
         ...mapGetters([  
             'isNotif', 'canBuild', 'getCtxCount',
         ]),
         ctxCount: function() { return this.getCtxCount(this.count) },
-        shortId: function() { return this.id.split('P')[0] },
-        selected: function() { return this.data.nanoswarm.resource === this.shortId },
+        shortId: function() { return this.id.split('P')[0] },        
     },
     methods: {
         ...mapMutations([
             'setActivePane',
         ]),
         ...mapActions([
-            'build', 'switchNano',
+            'build',
         ]),
     },
     created() {


### PR DESCRIPTION
Adds a nanoswarm icon to the cost breakdown of each resource, similar to the EMC shortcut. Clicking on the shortcut also updates the selected nanoswarm in the sidenav, and vise versa

![image](https://user-images.githubusercontent.com/667983/142964984-4d669b16-4b88-4355-b8b2-a9d439511e42.png)

![image](https://user-images.githubusercontent.com/667983/142965017-fb33094f-83fb-4cfd-8b47-7d6b85d289f3.png)

![image](https://user-images.githubusercontent.com/667983/143032126-d491f528-4630-4bde-9de4-d2d2ab889836.png)

![image](https://user-images.githubusercontent.com/667983/143032194-d05e4496-a174-4ec2-99bf-4fab21fbcb68.png)
