### PR TITLE
Fix nanoswarm selection

### DIFF
--- a/frontend/src/components/Buildable.vue
+++ b/frontend/src/components/Buildable.vue
@@ -113,7 +113,7 @@
                             
                         <div v-if="id == 'nanoswarm'" class="col-12">
                             <div class="small">{{ $t('selectResource') }}</div>
-                            <select class="form-control" v-model="selected" @change="switchNano(selected)">
+                            <select class="form-control" v-model="data['nanoswarm'].resource" @change="onChangeNano">
                                 <option value="energy">{{ $t('energy') }}</option>
                                 <option value="plasma">{{ $t('plasma') }}</option>
                                 <option value="meteorite">{{ $t('meteorite') }}</option>
@@ -278,14 +278,12 @@ export default {
         'format-number': FormatNumber,
     },
     data() {
-        return {
-            selected: null,
+        return {            
             automated: null,
             spaceshipParts: ['shield', 'engine', 'aero'],
         }
     },
-    created() {
-        this.selected = this.id == 'nanoswarm' ? this.data[this.id].resource : null
+    created() {        
         this.automated = this.data[this.id].auto ? this.data[this.id].auto : null
     },
     computed: {
@@ -304,6 +302,9 @@ export default {
         ...mapMutations([
             'toggleCollapsed', 'setAutoStorageUpgrade', 'setActivePane', 'setDisplayNanoswarmShortcut',
         ]),
+        onChangeNano(event) {
+            this.switchNano(event.target.value);
+        }
     },
 }
 </script>


### PR DESCRIPTION
Clicking on the nanoswarm shortcut in the side nav bar would not update the selected resource in the Nanoswarm pane. This fixes that issue

![image](https://user-images.githubusercontent.com/667983/142965621-2d451683-cac6-4cba-a6a9-e76454bc6a1c.png)
